### PR TITLE
Update documentation on the rudy branch

### DIFF
--- a/docs/action.md
+++ b/docs/action.md
@@ -70,6 +70,10 @@ type Location = {
 }
 ```
 
+## The error key
+RFR will ignore actions which contain a truthy `error` key.
+This is in case you want to use a different middleware to handle errors.
+
 ## Conclusion
 You will rarely need to inspect the `meta` key. It's primarily for use by our `location` reducer. However, a common
 use for it is to use the `kind` key to make some determinations in your

--- a/docs/addRoutes.md
+++ b/docs/addRoutes.md
@@ -1,0 +1,21 @@
+# addRoutes
+
+Sometimes you may want to dynamically add routes to routesMap,
+for example so that you can codesplit routesMap.
+You can do this using the `addRoutes` function.
+
+```javascript
+import { addRoutes } from 'redux-first-router'
+
+const newRoutes = {
+  DYNAMIC_ROUTE: '/some/path'
+}
+
+store.dispatch(addRoutes(newRoutes))
+```
+
+The new routes are added to routesMap after the existing routes,
+so existing routes will take precedence over the newly added routes
+in the case that they overlap.
+
+See the [original documentation in a comment](https://github.com/faceyspacey/redux-first-router/issues/62#issuecomment-322558836)

--- a/docs/blocking-navigation.md
+++ b/docs/blocking-navigation.md
@@ -1,0 +1,139 @@
+# Blocking navigation
+
+Sometimes you may want to block navigation away from the current route,
+for example to prompt the user to save their changes.
+
+This is supported - here's how you use it:
+
+```js
+const routesMap = {
+   HOME: '/'
+   FOO: {
+      path: '/foo',
+      confirmLeave: (state, action) => {
+         if (!state.formComplete && action.type === 'HOME' ) {
+             return 'Are you sure you want to leave without completing your purchase?'
+         }
+     }
+  }
+}
+```
+
+So each route can have a `confirmLeave` option, and if you return a string it will be shown in the `confirm` yes|no dialog. If you return a falsy value such as undefined, the user will be able to navigate away from the current route without being shown any dialog.
+
+If you'd like to customize that dialog (which is required in React Native since there is no `window.confirm` in React Native), you can pass a `displayConfirmLeave` option to `connectRoutes` like so:
+
+```js
+const options = {
+  displayConfirmLeave: (message, callback) => {
+    showModalConfirmationUI({
+       message,
+       stay: () => callback(false),
+       leave: () => callback(true)
+    })
+  }
+}
+
+connectRoutes(history, routesMap, options)
+```
+> so `showModalConfirmationUI` is an example of a function you can make to display a confirmation modal. If the user presses **OK** call the `callback` with `true` to proceed with navigating to the the route the user was going to. And pass `false` to block the user. 
+
+One special thing to note is that if you define this function in the same scope that is likely created below, you can use `store.dispatch` to trigger showing the modal instead. You could even do:
+
+```js
+store.dispatch({ type: 'SHOW_BLOCK_NAVIGATION_MODAL', payload: { callback } })
+```
+
+and then grab the callback in your `<Modal />` component. Since this is happening solely on the client and the store will never need to serialize that `callback` (as you do when rehydrating from the server), this is a fine pattern. Redux store state can contain functions, components, etc, if you choose. The result in this case is something highly idiomatic when it comes to how you render the React component corresponding to the modal. *No imperative tricks required.*
+
+Here's a final example:
+
+*src/reducers/blockNavigation.js:*
+
+```js
+export default (state = {}, action = {}) => {
+  switch (type): {
+    case 'SHOW_BLOCK_NAVIGATION_MODAL':
+       const { message, canLeave } = action.payload
+       return { message, canLeave  }
+    case 'HIDE_BLOCK_NAVIGATION_MODEL':
+       return {}
+    default:
+       return state
+  }
+}
+```
+
+*src/components/BlockModal.js:*
+
+```js
+const BlockModal = ({ show, message, cancel, ok }) =>
+  !show 
+    ? null
+    : <div className={styles.modal}>
+        <h1>{message}</h1>
+
+        <div className={styles.modalFooter}>
+               <span onClick={cancel}>CANCEL</span>
+               <span onClick{ok}>OK</span>
+        </div>
+   </div>
+
+const mapState = ({ blockNavigation: { message, canLeave } }) => ({
+   show: !!message,
+   message,
+   cancel: () => canLeave(false),
+   ok: () => canLeave(true)
+})
+
+export default connect(mapState)(BlockModal)
+```
+> obviously you could wrap `<BlockModal />` in a [transition-group](https://github.com/faceyspacey/transition-group) to create a nice fadeIn/Out animation
+
+
+*src/components/App.js*
+
+```js
+export default () =>
+   <div>
+       <OtherStuff />
+       <BlockModal />
+   </div>
+```
+
+
+*src/configureStore.js:*
+```js
+const routesMap = {
+   HOME: '/'
+   FOO: {
+      path: '/foo',
+      confirmLeave: (state, action) => {
+         if (!state.formComplete && action.type === 'HOME' ) {
+             return 'Are you sure you want to leave without completing your purchase?'
+         }
+     }
+  }
+}
+
+const options = {
+  displayConfirmLeave: (message, callback) => {
+     const canLeave = can => {
+        store.dispatch({ type: 'HIDE_BLOCK_NAVIGATION_MODEL' }) // hide modal
+        return callback(can) // navigate to next route or stay where ur at
+     }
+
+     store.dispatch({ 
+       type: 'SHOW_BLOCK_NAVIGATION_MODAL',
+       payload: { message, canLeave } 
+     })
+  }
+}
+
+const { reducer, middleware, enhancer } = connectRoutes(history, routesMap, options)
+
+const rootReducer = combineReducers({ ...reducers, location: reducer })
+const middlewares = applyMiddleware(middleware)
+const enhancers = composeEnhancers(enhancer, middlewares)
+const store = createStore(rootReducer, preLoadedState, enhancers)
+```

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -97,6 +97,7 @@ type RouteObject = {
   toPath?: (value: string, key?: string) => string,
   fromPath?: (pathSegment: string, key?: string) => string,
   thunk?: (dispatch: Function, getState: Function) => Promise<any>,
+  confirmLeave?: ConfirmLeave,
 }
 ```
 
@@ -119,6 +120,15 @@ server side rendering is detected*, it will not be called because it will be ass
 `initialState` on the client hydrated from that. 2) on the server, on first load, it also WILL NOT be called because it is expected
 to be handled manually in order to allow you to syncronously `await` its result before sending your HTML to the client. See the
 [server side rendering](./docs/server-rendering.md) doc for the idiomatic way to do this.
+* **confirmLeave** is a function that can optionally block navigation away from the route.
+It receives the current redux state and the action as arguments.
+If you return a falsy value, navigation will be allowed. Otherwise, The default behaviour is to
+call `window.confirm` on attempted navigation, and display the string returned from
+`confirmLeave` as the message in the browser yes|no dialog. You can customize what happens
+when navigation is blocked using the `displayConfirmLeave` option to `routesMap` (see below).
+You must do this on react-native, since there is no `window.confirm`.
+In this case, you can return any type of value you want.
+See this [blocking navigation](./blocking-navigation.md) for more details
 
 
 ## Options
@@ -136,7 +146,8 @@ type Options = {
   onAfterChange?: (Dispatch, GetState) => void,
   initialDispatch?: boolean, // default: true
   onBackNext?: (Dispatch, GetState, HistoryLocation, Action) => void,
-  querySerializer?: {parse: Function, stringify: Function}
+  querySerializer?: {parse: Function, stringify: Function},
+  displayConfirmLeave?: DisplayConfirmLeave,
 }
 ```
 
@@ -175,6 +186,11 @@ const options = {
 ```
 
 * **querySerializer** - an object with `parse` and `stringify` methods, such as the `query-string` or `qs` libraries (or anything handmade). This will be used to handle querystrings. Without this option, querystrings are ignored silently.
+
+* **displayConfirmLeave** - A function receiving `message` and `callback` when navigation is blocked with
+`confirmLeave`. The message is the return value from `confirmLeave`. The callback can be called with `true`
+to unblock the navigation, or with `false` to cancel the navigation.
+See this [blocking navigation](./blocking-navigation.md) for more details
 
 
 > See the [Redux Navigation](./redux-navigation) docs for info on how to use *React Navigation* with this package. We think you're gonna love it :)

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -105,7 +105,13 @@ type RouteObject = {
 When using* **Redux First Router**, *do not dispatch payloads that are primitives such as `number` or `string`.*
 
 Features:
-* **route as a string** is simply a path to match to an action type without any transformations
+* **path** (or the string passed in place of the object) is simply a URL pathname
+(just the path, not the query string) to match to an action type.
+You can implement basic cases by simply passing a literal path, e.g. `'/'` or `'/about'`.
+You can have dynamic segments by using a colon (e.g. `'/users/:userId'`). In this case, the
+corresponding action has a key `payload.userId` with the appropriate value.
+You can also implement more complex cases such as regular expressions, optional parameters,
+and multi segment parameters. See the docs on [URL parsing](./url-parsing.md) for more details.
 * **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalizedWords
 * **toPath** will one-by-one take the keys and values of your payload object and transform them into path segments. So for a payload
 with multiple key/value pairs, it will call `toPath` multiple times, passing in the individual value as the first argument

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -72,13 +72,18 @@ and multi segment parameters. See the docs on [URL parsing](./url-parsing.md) fo
 Path is **optional**. If you do not provide it, the action will not be synced with the URL,
 but you can still use the `thunk` option to declaratively specify which thunks will occur
 in response to which actions. See the [example](../examples/pathlessRoutes.js) for more details.
-* **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalizedWords
+* **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalized
 * **toPath** will one-by-one take the keys and values of your payload object and transform them into path segments. So for a payload
 with multiple key/value pairs, it will call `toPath` multiple times, passing in the individual value as the first argument
 and the individual key name as the second argument.
-* **fromPath** will do the inverse, taking each dynamic path *:segment* and its name (in this case "segment") and pass it to
+If you do not provide a function, the default behaviour is to convert payload params with multiple segments into
+arrays containing each segment, and to apply the `capitalizedWords` transformation to other segments if that option is set. If you provide your own function, no other transformations are applied.
+* **fromPath** will do the inverse, taking each dynamic path *:segment* and its name(in this case "segment") and passing it to
 `fromPath` multiple times. The first argument is the segment and the second its name as delinated in your `routesMap` object
 after colons.
+If `fromPath` is not provided, the default behaviour is to parse segments into numbers if possible,
+and otherwise to apply the `capitalizedWords` transformation if that option is set.
+If you pass a function to `fromPath`, no transformations occur other than those that your function performs.
 * **thunk** is a function just like what you dispatch when using the `redux-thunk` middleware, taking `dispatch` and `getState`
 arguments. NOTE: you do NOT need `redux-thunk` for this to work. On the client, the thunk will be called any time the middleware
 detects a matching route. However to properly manage server-side rendering, there are 2 optimizations: 1) on first load on the client *if

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -157,6 +157,7 @@ type Options = {
   initialDispatch?: boolean, // default: true
   querySerializer?: {parse: Function, stringify: Function},
   displayConfirmLeave?: DisplayConfirmLeave,
+  basename?: string,
   extra?: any,
 }
 ```
@@ -201,6 +202,10 @@ const options = {
 `confirmLeave`. The message is the return value from `confirmLeave`. The callback can be called with `true`
 to unblock the navigation, or with `false` to cancel the navigation.
 See this [blocking navigation](./blocking-navigation.md) for more details
+
+* **basename** - a URL path prefix that will be prepended to the URL. For example,
+using a `basename` of `'/playground'`, A route with the path `'/home'` would correspond
+to the URL path `'/playground/home'`
 
 * **extra** - An optional value that will be passed as part of the third `bag` argument to all route callbacks,
 including `thunk`, `onBeforeChange`, etc. It works much like the

--- a/docs/connectRoutes.md
+++ b/docs/connectRoutes.md
@@ -112,6 +112,9 @@ You can have dynamic segments by using a colon (e.g. `'/users/:userId'`). In thi
 corresponding action has a key `payload.userId` with the appropriate value.
 You can also implement more complex cases such as regular expressions, optional parameters,
 and multi segment parameters. See the docs on [URL parsing](./url-parsing.md) for more details.
+Path is **optional**. If you do not provide it, the action will not be synced with the URL,
+but you can still use the `thunk` option to declaratively specify which thunks will occur
+in response to which actions. See the [example](../examples/pathlessRoutes.js) for more details.
 * **capitalizedWords** when true will break apart hyphenated paths into words, each with the first character capitalizedWords
 * **toPath** will one-by-one take the keys and values of your payload object and transform them into path segments. So for a payload
 with multiple key/value pairs, it will call `toPath` multiple times, passing in the individual value as the first argument

--- a/docs/low-level-api.md
+++ b/docs/low-level-api.md
@@ -10,9 +10,16 @@ import { actionToPath, pathToAction } from 'redux-first-router'
 
 const { routesMap } = store.getState().location
 
-const path = actionToPath(action, routesMap)
-const action = pathToAction(path, routesMap)
+const path = actionToPath(action, routesMap, querySerializer)
+const action = pathToAction(path, routesMap, querySerializer, basename)
 ```
+
+The `querySerializer` argument is optional and the same as the one passed to `connectRoutes`.
+It defaults to undefined.
+
+The `basename` argument to `pathToAction` is optional and works the same way as the one passed to routesMap.
+It defaults to the value passed the last time `connectRoutes` was called.
+`actionToPath` does not apply any `basename` transformation.
 
 You will need the `routesMap` you made, which you can import from where you created it or you can
 get any time from your store.

--- a/docs/url-parsing.md
+++ b/docs/url-parsing.md
@@ -1,0 +1,155 @@
+# URL parsing
+
+Besides the simple option of matching a literal path, all matching capabilities of the `path-to-regexp` package we use are now supported,  *except* [unnamed parameters](https://github.com/pillarjs/path-to-regexp#unnamed-parameters).
+
+Let's go through what we support. Usually it's best to start with the simplest example, but I think most people looking at this get this stuff. We'll start with one of the more complicated use cases just to see how far we can take this:
+
+## Multi Segment Parameters
+
+So for example, imagine you're github.com and you're now using Redux-First Router :),  and you need to match all the potential dynamic paths for files in repos, here's how you do it:
+
+```js
+const routesMap = {
+   REPO: '/:user/:repo/block/:branch/:filePath+'
+}
+```
+
+So that will match:
+- https://github.com/faceyspacey/redux-first-router/blob/master/src/connectRoutes.js
+- https://github.com/faceyspacey/redux-first-router/blob/master/src/pure-utils/pathToAction.js
+- etc
+
+but not:
+- https://github.com/faceyspacey/redux-first-router/blob/master
+
+And if you visit that URL, you will see it in fact doesn't exist. If it did, you would use an asterisk (for 0 or more matches as in regexes) like so:
+
+```js
+const routesMap = {
+   REPO: '/:user/:repo/block/:branch/:filePath*'
+}
+```
+
+So the above 2 options will match a varying number of path segments. Here's what a corresponding action might look like:
+
+
+```js
+const action = {
+   type: 'REPO',
+   payload: {
+       user: 'faceyspacey',
+       repo: 'redux-first-router',
+       branch: 'master',
+       filePath: 'src/pure-utils/pathToAction.js'
+   }
+}
+```
+
+Pretty cool, eh! 
+
+> The inspiration actually came from a [PR](https://github.com/CompuIves/codesandbox-client/pull/49) I did to CodeSandBox. I didn't actually implement this there, but I was thinking about it around that time. I.e. that CodeSandBox should have the full file paths in the URLs like github. Currently it's as a URL-encoded query param, but in the future *(perhaps with RFR)*, they'll be able to do what Github does as well.
+
+## Optional Single Segment Parameters
+
+However, you usually just want to add optional *single segment* params like this:
+
+```js
+const routesMap = {
+   ISSUES: '/:user/:repo/issues/:id?'
+}
+```
+
+So with that you can visit both:
+- `https://github.com/faceyspacey/redux-first-router/issues`
+- `https://github.com/faceyspacey/redux-first-router/issues/83`
+
+Here's the 2 actions that would match that respectively:
+
+- `const action = {  type: 'ISSUES' }`
+- `const action = {  type: 'ISSUES', payload: { id: 83} }`
+
+And that's basically the *"80% use-case"* most powerful feature here. I.e. when you want to use the same type for a few similar URLs, while getting an optional parameter.
+
+> note: you can also have optional params in the middle, eg: `/foo/:optional?/bar/:anotherOptional?` So all 3 of `/foo/bla/bar/baz` and `/foo/bar/baz` and `/foo/bar` will match :)
+
+## Optional Static Segments ("aliases")
+
+The absolute most common *(and simpler*) use case for such a thing is when you want `/items` and `/items/list` to have the same type **(because they are aliases of each other )**. You accomplish it slightly differently:
+
+```js
+const routesMap = {
+  HOME: '/home/(list)?',
+}
+```
+
+or
+
+```js
+const routesMap = {
+  HOME: '/home/(list)*',
+}
+```
+
+Both are the same. It would be nice if you didn't have to wrap `list` in parentheses, but you have to. That's fine. *Keep in mind this isn't a parameter; the 2nd path segment has to be `list` or not be there.*
+
+Also, the common convention we should use is the the question mark `?` instead of the asterisk `*`. We should reserve the asterisk for where it has unique capabilities, specifically the ability to match a varying number of path segments (along with `+`) as in the initial examples with the github file paths.
+
+## Regexes
+
+Another thing to note about the last one is that `(list)` is in fact a regex. So you can use regexes to further refine what paths match. You can do so with parameter segments as well:
+
+```js
+const routesMap = {
+  HOME: '/posts/:id(\\d+)',
+}
+```
+
+So essentially you follow a dynamic segment with a regex in parentheses and the param will have to match the regex. So this would match:
+- `/posts/123`
+but this wouldn't:
+- `/posts/foo-bar`
+
+
+## Multiple *Multi Segment Parameters*
+Last use case: say you want to have multiple params with a varying number of segments. Here's how you do it:
+
+```js
+const routesMap = {
+  HOME: '/home/:segments1+/bla/:segments2+',
+}
+```
+
+So a url like `/home/foo/bar/bla/baz/bat/cat` will result in an `action` like this:
+
+```js
+const action = {
+   type: 'HOME',
+   payload: {
+       segments1: 'foo/bar',
+       segments2: 'baz/bat/cat'
+   }
+}
+```
+
+So yes, you can have multiple *"multi segments parameters"*.
+
+One thing to note is you could also accomplish this like this: `HOME: '/home/:segments1(.*)/bla/:segments2(.*)'`.
+
+----
+
+Final reminder: if you do plan to use *multi segment parameters*, they have to be named. This won't work:
+`/home/(.*)/bla/(.*)`.
+
+Well, the truth is it will, and given the previous URL you will have a payload of:
+
+```js
+const action = {
+   type: 'HOME',
+   payload: {
+       0: 'foo/bar',
+       1: 'baz/bat/cat'
+   }
+}
+```
+
+But consider that "undefined" functionality. Don't rely on that. Name your segments! Like any other key in your payload. That's the goal here. Originally I had the idea of making an array at `payload.segments`, but then I realized it was possible to name them. So naming all params is the RFR way.

--- a/examples/pathlessRoutes.js
+++ b/examples/pathlessRoutes.js
@@ -1,0 +1,55 @@
+// Note: this is just a proof of concept
+
+const routesMap = {
+  HOME: '/',  // path only route
+  LIST: {     // route object (with a path)
+    path: '/list/:slug',
+    thunk: async (dispatch, getState) => {
+       const { slug } = getState().location.payload
+       const response = await fetch(`/api/items/${slug}`)
+       const items = await data.json()
+       
+       dispatch({ type: 'ITEMS_FETCHED', payload: { items } })
+    }
+  },
+  UPDATE_COUNTERS: {    // pathless route (for the purpose of uniform + idiomatic thunks)
+    thunk: async (dispatch, getState, { action, extra: { api } }) => {
+       const { id } = action.payload
+       const counters = await api.fetchCounters(id)
+
+       dispatch({ type: 'COUNTERS_FETCHED', payload: { id, counters } })
+    }  
+  }
+}
+
+//=====================
+
+import api from './api'
+
+connectRoutes(history, routesMap, { extra: api })
+
+/*
+HOW THIS WORKS:
+When you dispatch type UPDATE_COUNTERS, its corresponding thunk in the routesMap will be called :)
+WHAT'S ITS PURPOSE? 
+Can't I just use regular middleware. Of course you still can, but if you're primarily using redux-thunk,
+it's better to have your async actions (aka "thunks") be uniform. This does that. Now all your thunks 
+can look the same.
+The URL-centric "contract" of the routesMap in general prevents action explosion (i.e. an explosion in the number 
+of actions you have). That makes your app easier to manage. By adding non-URL-centric "routes," it's essentially a 
+next step of that goal/benefit. Though the # of actions could explode here too--at least you now have some sort of 
+structure guiding you. 
+In addition, since RFR thunks implicitly have the initial action dispatched, your actual "thunk"
+function is easier--i.e. you don't have to create an async thunk that dispatches a "setup action" to trigger
+loading... spinners; you only have to dispatch the "follow-up action" with the data.
+Pathless routes are small, but it's a key ingredient in formalizing the vision here, especially when there are so 
+many "learners" trying to grok the otherwise complicated Redux approach (especially since most people are still 
+coming from OOP).
+ Now you're stack is: React, Redux, Redux-First Router (soon to be called "Rudy"). And you and learners and all of us
+ have less to think about in terms of javascript fatigue and all the options that have been typical of the React
+ community. You can build truly advanced apps via simplified yet powerful idioms, thanks to Rudy. And other coders
+ can have a very good idea what's going on in your app, just as they would when looking at a Rails app. Ultimately
+ Rudy/RFR really fills a void that the React/NPM style of development hasn't fostered: truly standard idioms/bestPractices.
+ So that means you get the best of React/NPM--modularity + choices + ecosystem--and structure where/when you need it.
+ 
+ It's time to win everbody!


### PR DESCRIPTION
Basically I went through the list of changes in the [Road to rudy](https://github.com/ScriptedAlchemy/redux-first-router#road-to-rudy) section of the README. and either copy/pasted in the contents of @faceyspacey's issue comments and/or updated the existing documentation as appropriate.

It could probably still do with a cleanup, but at least the features that were announced on the README are documented in the main docs folder.